### PR TITLE
Use -chromedebug flag to start debugger.

### DIFF
--- a/src/chrome/chromeDebugAdapter.ts
+++ b/src/chrome/chromeDebugAdapter.ts
@@ -167,7 +167,7 @@ export class ChromeDebugAdapter implements IDebugAdapter {
 
                 // Start with remote debugging enabled
                 const port = args.port || Math.floor((Math.random() * 10000) + 10000);
-                const chromeArgs: string[] = ['--remote-debugging-port=' + port];
+                const chromeArgs: string[] = ['-chromedebug', '--remote-debugging-port=' + port];
 
                 chromeArgs.push(path.resolve(args.cwd, args.file));
 


### PR DESCRIPTION
Looks like everything changed compared to my local version. This change allows to operate KodeStudio from command line.
